### PR TITLE
Removed iframe from nav-global to fix warning in Chrome.

### DIFF
--- a/_includes/themes/the-program/default.html
+++ b/_includes/themes/the-program/default.html
@@ -25,8 +25,6 @@
 						<li class="page"><a href="/pages.html">pages</a></li>
 						<li class="category"><a href="/categories.html">categories</a></li>
 						<li class="tag"><a href="/tags.html">tags</a></li>
-						<li class="forkme"><div><iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=plusjade&repo=jekyll-bootstrap&type=fork&count=true"
-									allowtransparency="true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe></div></li>
 					</ul>
 				</nav>
 			</div><!-- unit-inner -->


### PR DESCRIPTION
Chrome was preventing use of the theme - it looks like the src url used by
the iframe no longer exists (I get a 404) - and was displaying the message:

> > For security reasons, framing is not allowed

The message was displayed in an alert-style box. When I clicked 'Ok' to dismiss,
I got redirected to http://markdotto.github.com/github-buttons/github-btn.html?user=plusjade&repo=jekyll-bootstrap&type=fork&count=true
and got a 404.

Removing the iframe fixes this issue.
