### PR TITLE
Remove the iFrame element from the navigation

### DIFF
--- a/_includes/themes/the-program/default.html
+++ b/_includes/themes/the-program/default.html
@@ -25,8 +25,6 @@
 						<li class="page"><a href="/pages.html">pages</a></li>
 						<li class="category"><a href="/categories.html">categories</a></li>
 						<li class="tag"><a href="/tags.html">tags</a></li>
-						<li class="forkme"><div><iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=plusjade&repo=jekyll-bootstrap&type=fork&count=true"
-									allowtransparency="true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe></div></li>
 					</ul>
 				</nav>
 			</div><!-- unit-inner -->


### PR DESCRIPTION
# Greetings!

Thanks for an awesome theme. So I am totally new at pull requests, please be kind to a novice and stranger. I wanted to suggest removing the current Fork Me iFrame so that github doesn't launch a js alert and change the page to the github 404 page. If anything lt me know better etiquette for pullrequests.

...rom github saying iFrames were not allowed. I needed to remove it.
